### PR TITLE
Add a simple roundtrip fuzz target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ However after noticing performance issues, I have gradually rewritten both the c
 C implementation (and that's just the raw format without framing!). Admittedly they pack plenty of optimizations in there (lots of intentionally reading beyond buffer boundaries for the sake of performance),
 but I'm proud to say that I achieved similar performance in just 400 lines of competely safe Rust.
 
+# Code Fuzzing
+
+Fuzzing requires a nightly toolchain. Fuzzing for this project is currently confirmed to work with:
+
+```
+rustc 1.44.0-nightly (f509b26a7 2020-03-18)
+```
+
+## Running
+
+```
+cargo install cargo-fuzz
+cargo +nightly fuzz run roundtrip_fuzz
+```

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "lz-fear-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.lz-fear]
+path = "../"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "roundtrip_fuzz"
+path = "fuzz_targets/roundtrip_fuzz.rs"

--- a/fuzz/fuzz_targets/roundtrip_fuzz.rs
+++ b/fuzz/fuzz_targets/roundtrip_fuzz.rs
@@ -1,24 +1,23 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use lz_fear::framed::{CompressionSettings, LZ4FrameReader};
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 
 fuzz_target!(|data: &[u8]| {
-    // TODO - What's the minimum input size for lz4?
-    if data.len() >= 31 {
-        let input = Cursor::new(data);
-        let mut output = Vec::new();
+    let input = Cursor::new(data);
+    let mut output = Vec::new();
 
-        CompressionSettings::default()
-            .content_checksum(true)
-            .independent_blocks(true)
-            .compress_with_size(input, &mut output)
-            .expect("Could not compress input data");
+    CompressionSettings::default()
+        .content_checksum(true)
+        .independent_blocks(true)
+        .compress(input, &mut output) //_with_size(input, &mut output)
+        .expect("Could not compress input data");
 
-        let mut lz4_reader = LZ4FrameReader::new(Cursor::new(output))
-            .expect("Could not create frame reader")
-            .into_read();
+    let mut lz4_reader = LZ4FrameReader::new(Cursor::new(output))
+        .expect("Could not create frame reader")
+        .into_read();
 
-        // TODO - Completely decompress and compare decompressed output to initial fuzz input
-    }
+    let mut roundtripped = Vec::new();
+    lz4_reader.read_to_end(&mut roundtripped).expect("Could not read decompressed data");
+    assert!(roundtripped.iter().eq(data));
 });

--- a/fuzz/fuzz_targets/roundtrip_fuzz.rs
+++ b/fuzz/fuzz_targets/roundtrip_fuzz.rs
@@ -1,0 +1,24 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use lz_fear::framed::{CompressionSettings, LZ4FrameReader};
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    // TODO - What's the minimum input size for lz4?
+    if data.len() >= 31 {
+        let input = Cursor::new(data);
+        let mut output = Vec::new();
+
+        CompressionSettings::default()
+            .content_checksum(true)
+            .independent_blocks(true)
+            .compress_with_size(input, &mut output)
+            .expect("Could not compress input data");
+
+        let mut lz4_reader = LZ4FrameReader::new(Cursor::new(output))
+            .expect("Could not create frame reader")
+            .into_read();
+
+        // TODO - Completely decompress and compare decompressed output to initial fuzz input
+    }
+});


### PR DESCRIPTION
This isn't really a complete addition, more of a jumpstart for anyone who wants to finish adding code fuzzing to this repo. It currently panics pretty early, I'm not sure if that's me not using the library correctly or the fuzzer catching legitimately failing cases.

More references can be found from [this comment](https://www.reddit.com/r/rust/comments/ge3kee/lzfear_a_purerust_nounsafe_lz4_implementation/fpl8sp7/)