### PR TITLE
Disable unused feature `rand` in twox-hash crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/main--/rust-lz-fear"
 
 [dependencies]
 byteorder = "1.3.1"
-twox-hash = "1.5.0"
+twox-hash = { version = "1.5.0", default-features = false }
 thiserror = "1.0"
 fehler = "1.0"
 bitflags = "1.2.1"


### PR DESCRIPTION
This brings down the amount of unsafe code in the dependency tree from 1000 to 265, according to [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger).