### PR TITLE
tests::output_equivalence: Use a tmp file instead of /usr/bin/cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bitflags = "1.2.1"
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.7.3"
+tempfile = "3.1.0"
 
 [[bench]]
 name = "my_benchmark"

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -83,10 +83,12 @@ fn run_test() {
         let input = std::fs::File::open(env::current_exe().unwrap()).unwrap(); //std::io::Cursor::new(&[1,3,3,7]);
         let mut output = Vec::new();
         if bits & 16 != 0 {
-            settings.compress_with_size(input, &mut output);
+            settings.compress_with_size(input, &mut output)
+                .expect("CompressionSettings::compress_with_size failed");
             args.push("--content-size");
         } else {
-            settings.compress(input, &mut output);
+            settings.compress(input, &mut output)
+                .expect("CompressionSettings::compress failed");
         }
         
         let reference_output = run_cmd(&args);

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -1,7 +1,5 @@
 use lz_fear::framed::CompressionSettings;
 use std::env;
-use std::path::Path;
-use std::ffi::OsStr;
 use std::io::Write;
 use std::process::Command;
 use tempfile::NamedTempFile;


### PR DESCRIPTION
This fixes the test on systems where /usr/bin/cargo does not exist.