### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ culpa = "1.0"
 bitflags = "2.4.2"
 
 [dev-dependencies]
-criterion = "0.3"
-rand = "0.7.3"
-tempfile = "3.1.0"
+criterion = "0.5"
+rand = "0.8.5"
+tempfile = "3.10.0"
 
 [[bench]]
 name = "my_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lz-fear"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["main() <main@ehvag.de>"]
-edition = "2018"
+edition = "2021"
 
 description = "A fast pure-rust no-unsafe implementation of LZ4 compression and decompression"
 keywords = ["compression", "lz4", "compress", "decompression", "decompress"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lz-fear"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["main() <main@ehvag.de>"]
 edition = "2018"
 
@@ -13,11 +13,11 @@ readme = "README.md"
 repository = "https://github.com/main--/rust-lz-fear"
 
 [dependencies]
-byteorder = "1.3.1"
-twox-hash = { version = "1.5.0", default-features = false }
+byteorder = "1.5"
+twox-hash = { version = "1.6.3", default-features = false }
 thiserror = "1.0"
-fehler = "1.0"
-bitflags = "1.2.1"
+culpa = "1.0"
+bitflags = "2.4.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/examples/dolz4.rs
+++ b/examples/dolz4.rs
@@ -1,7 +1,7 @@
 use lz_fear::framed::CompressionSettings;
 use std::fs::File;
 use std::{io, env};
-use fehler::throws;
+use culpa::throws;
 
 #[throws(io::Error)]
 fn main() {

--- a/src/framed/compress.rs
+++ b/src/framed/compress.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Write, Seek, SeekFrom, ErrorKind};
 use std::mem;
 use twox_hash::XxHash32;
 use thiserror::Error;
-use fehler::{throws};
+use culpa::{throws};
 
 use super::{MAGIC, INCOMPRESSIBLE, WINDOW_SIZE};
 use super::header::{Flags, BlockDescriptor};

--- a/src/framed/compress.rs
+++ b/src/framed/compress.rs
@@ -148,7 +148,7 @@ impl<'a> CompressionSettings<'a> {
     pub fn compress_with_size<R: Read + Seek, W: Write>(&self, mut reader: R, writer: W) {
         // maybe one day we can just use reader.stream_len() here: https://github.com/rust-lang/rust/issues/59359
         // then again, we implement this to ignore the all bytes before the cursor which stream_len() does not
-        let start = reader.seek(SeekFrom::Current(0))?;
+        let start = reader.stream_position()?;
         let end = reader.seek(SeekFrom::End(0))?;
         reader.seek(SeekFrom::Start(start))?;
 
@@ -268,12 +268,10 @@ impl<'a> CompressionSettings<'a> {
                 in_buffer.extend_from_slice(block_initializer);
 
                 table = template_table.clone();
-            } else {
-                if in_buffer.len() > WINDOW_SIZE {
-                    let how_much_to_forget = in_buffer.len() - WINDOW_SIZE;
-                    table.offset(how_much_to_forget);
-                    in_buffer.drain(..how_much_to_forget);
-                }
+            } else if in_buffer.len() > WINDOW_SIZE {
+                let how_much_to_forget = in_buffer.len() - WINDOW_SIZE;
+                table.offset(how_much_to_forget);
+                in_buffer.drain(..how_much_to_forget);
             }
         }
         writer.write_u32::<LE>(0)?;
@@ -303,7 +301,7 @@ impl<'a> Write for NoPartialWrites<'a> {
         }
 
         let amt = data.len();
-        let (a, b) = mem::replace(&mut self.0, &mut []).split_at_mut(data.len());
+        let (a, b) = mem::take(&mut self.0).split_at_mut(data.len());
         a.copy_from_slice(data);
         self.0 = b;
         Ok(amt)

--- a/src/framed/decompress.rs
+++ b/src/framed/decompress.rs
@@ -5,7 +5,7 @@ use std::cmp;
 use std::convert::TryInto;
 use twox_hash::XxHash32;
 use thiserror::Error;
-use fehler::{throw, throws};
+use culpa::{throw, throws};
 
 use super::{MAGIC, INCOMPRESSIBLE, WINDOW_SIZE};
 use super::header::{self, Flags, BlockDescriptor};
@@ -54,7 +54,7 @@ impl<R: Read> Read for LZ4FrameIoReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> usize {
         let mybuf = self.fill_buf()?;
         let bytes_to_take = cmp::min(mybuf.len(), buf.len());
-        &mut buf[..bytes_to_take].copy_from_slice(&mybuf[..bytes_to_take]);
+        (&mut buf[..bytes_to_take]).copy_from_slice(&mybuf[..bytes_to_take]);
         self.consume(bytes_to_take);
         bytes_to_take
     }

--- a/src/framed/decompress.rs
+++ b/src/framed/decompress.rs
@@ -54,7 +54,7 @@ impl<R: Read> Read for LZ4FrameIoReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> usize {
         let mybuf = self.fill_buf()?;
         let bytes_to_take = cmp::min(mybuf.len(), buf.len());
-        (&mut buf[..bytes_to_take]).copy_from_slice(&mybuf[..bytes_to_take]);
+        buf[..bytes_to_take].copy_from_slice(&mybuf[..bytes_to_take]);
         self.consume(bytes_to_take);
         bytes_to_take
     }
@@ -228,7 +228,7 @@ impl<R: Read> LZ4FrameReader<R> {
         if self.flags.block_checksums() {
             let checksum = reader.read_u32::<LE>()?;
             let mut hasher = XxHash32::with_seed(0);
-            hasher.write(&buf);
+            hasher.write(buf);
             if hasher.finish() != checksum.into() {
                 throw!(Error::BlockChecksumFail);
             }
@@ -245,9 +245,9 @@ impl<R: Read> LZ4FrameReader<R> {
         };
         // decompress or copy, depending on whether this block is compressed
         if is_compressed {
-            raw::decompress_raw(&buf, dec_prefix, output, self.block_maxsize)?;
+            raw::decompress_raw(buf, dec_prefix, output, self.block_maxsize)?;
         } else {
-            output.extend_from_slice(&buf);
+            output.extend_from_slice(buf);
         }
         // finally, push data back into the window as needed
         if let Some(window) = self.carryover_window.as_mut() {
@@ -258,7 +258,7 @@ impl<R: Read> LZ4FrameReader<R> {
                     // remove as many bytes from front as we are replacing
                     window.drain(..surplus_bytes);
                 }
-                window.extend_from_slice(&output);
+                window.extend_from_slice(output);
             } else {
                 // TODO: optimize this case to avoid the copy
                 window.clear();
@@ -274,7 +274,7 @@ impl<R: Read> LZ4FrameReader<R> {
         }
 
         if let Some(hasher) = self.content_hasher.as_mut() {
-            hasher.write(&output);
+            hasher.write(output);
         }
     }
 }

--- a/src/framed/header.rs
+++ b/src/framed/header.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 use thiserror::Error;
-use fehler::{throw, throws};
+use culpa::{throw, throws};
 use bitflags::bitflags;
 
 bitflags! {

--- a/src/raw/compress/mod.rs
+++ b/src/raw/compress/mod.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use std::io::Write;
 use std::convert::{TryInto, TryFrom};
 use byteorder::{ByteOrder, NativeEndian, WriteBytesExt, LE};
-use fehler::{throws};
+use culpa::{throws};
 
 type Error = std::io::Error;
 

--- a/src/raw/decompress.rs
+++ b/src/raw/decompress.rs
@@ -1,7 +1,7 @@
 use byteorder::{ReadBytesExt, LE};
 use std::io::{self, Cursor, Read, ErrorKind};
 use thiserror::Error;
-use fehler::{throws, throw};
+use culpa::{throws, throw};
 
 /// Errors when decoding a raw LZ4 block.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Error)]

--- a/src/raw/decompress.rs
+++ b/src/raw/decompress.rs
@@ -140,7 +140,7 @@ fn copy_overlapping(offset: usize, match_len: usize, prefix: &[u8], output: &mut
 
 #[cfg(test)]
 pub mod test {
-    use fehler::throws;
+    use culpa::throws;
     use super::{decompress_raw, Error};
 
     #[throws]


### PR DESCRIPTION
`fehler` is deprecated, replaced it with culpa as recomended.
Other than that no logic changes